### PR TITLE
Always url-encode supplied paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ allprojects {
 Step 2. Add the dependency on project's `build.gradle`:
 ```
 dependencies {
-        implementation 'com.github.imagekit-developer:imagekit-java:1.0.3'
+        implementation 'com.github.imagekit-developer:imagekit-java:1.0.4_UNIMARKET-SNAPSHOT'
 }
 ```
 ### Maven users
@@ -61,7 +61,7 @@ Step 2. Add the dependency in POM file:
 <dependency>
     <groupId>com.github.imagekit-developer</groupId>
     <artifactId>imagekit-java</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4_UNIMARKET-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -122,7 +122,7 @@ String url = ImageKit.getInstance().getUrl(options);
 ```
 The result in a URL like
 ```
-https://ik.imagekit.io/your_imagekit_id/tr:w-400,h-600/default-image.jpg?v=123&ik-sdk-version=java-1.0.3
+https://ik.imagekit.io/your_imagekit_id/tr:w-400,h-600/default-image.jpg?v=123&ik-sdk-version=java-1.0.4_UNIMARKET-SNAPSHOT
 ```
 
 **2. Using full image URL**
@@ -147,7 +147,7 @@ String url = ImageKit.getInstance().getUrl(options);
 The results in a URL like
 
 ```
-https://ik.imagekit.io/your_imagekit_id/default-image.jpg?tr=w-400,h-600&ik-sdk-version=java-1.0.3
+https://ik.imagekit.io/your_imagekit_id/default-image.jpg?tr=w-400,h-600&ik-sdk-version=java-1.0.4_UNIMARKET-SNAPSHOT
 ```
 
 The ```.getUrl()``` method accepts the following parameters
@@ -187,7 +187,7 @@ String url = ImageKit.getInstance().getUrl(options);
 
 Sample Result URL -
 ```
-https://ik.imagekit.io/your_imagekit_id/default-image.jpg?tr=h-300&w-400:rt-90&ik-sdk-version=java-1.0.3
+https://ik.imagekit.io/your_imagekit_id/default-image.jpg?tr=h-300&w-400:rt-90&ik-sdk-version=java-1.0.4_UNIMARKET-SNAPSHOT
 ```
 
 **2. Sharpening and contrast transforms and a progressive JPG image**
@@ -215,7 +215,7 @@ String url = ImageKit.getInstance().getUrl(options);
 Note that because the `src` parameter was used, the transformation string gets added as a query parameter.
 
 ```
-https://ik.imagekit.io/your_imagekit_id/default-image.jpg?tr=f-jpg&pr-true&e-sharpen&e-contrast-1&ik-sdk-version=java-1.0.3
+https://ik.imagekit.io/your_imagekit_id/default-image.jpg?tr=f-jpg&pr-true&e-sharpen&e-contrast-1&ik-sdk-version=java-1.0.4_UNIMARKET-SNAPSHOT
 ```
 
 **3. Signed URL that expires in 300 seconds with the default URL endpoint and other query parameters**
@@ -236,7 +236,7 @@ String url = ImageKit.getInstance().getUrl(options);
 ```
 **Sample Result URL**
 ```
-https://ik.imagekit.io/your_imagekit_id/tr:h-600,w-400/default-image.jpg?ik-t=1567358667&ik-s=f2c7cdacbe7707b71a83d49cf1c6110e3d701054&ik-sdk-version=java-1.0.3
+https://ik.imagekit.io/your_imagekit_id/tr:h-600,w-400/default-image.jpg?ik-t=1567358667&ik-s=f2c7cdacbe7707b71a83d49cf1c6110e3d701054&ik-sdk-version=java-1.0.4_UNIMARKET-SNAPSHOT
 ```
 
 **List of transformations**

--- a/imagekit-sdk/build.gradle
+++ b/imagekit-sdk/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'io.imagekit.sdk'
-version '1.0.3'
+version '1.0.4_UNIMARKET-RELEASE'
 
 sourceCompatibility = 1.8
 

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/constants/Version.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/constants/Version.java
@@ -1,5 +1,5 @@
 package io.imagekit.sdk.constants;
 
 public class Version {
-    public static final String VERSION_CODE="java-1.0.3";
+    public static final String VERSION_CODE="java-1.0.4_UNIMARKET-SNAPSHOT";
 }

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/QueryMaker.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/QueryMaker.java
@@ -1,20 +1,20 @@
 package io.imagekit.sdk.tasks;
 
 public class QueryMaker {
-    private String query;
+    private final StringBuilder query = new StringBuilder();
 
-    public void put(String q){
-        if (null!=query){
-            query+="&";
+    public void put(String q) {
+        if (query.length() != 0) {
+            query.append("&");
         }
-        else {
-            query="";
-        }
-        query+=q;
+        query.append(q);
     }
 
-    public String  get(){
-        return query;
+    public String get() {
+        return query.toString();
     }
 
+    public String getAsQueryString() {
+        return "?" + get();
+    }
 }

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/QueryMaker.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/QueryMaker.java
@@ -11,6 +11,9 @@ public class QueryMaker {
     }
 
     public String get() {
+        if (query.length() == 0){
+            return null;
+        }
         return query.toString();
     }
 

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/UrlGen.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/UrlGen.java
@@ -8,6 +8,9 @@ import org.apache.commons.codec.digest.HmacUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class UrlGen {
@@ -29,7 +32,12 @@ public class UrlGen {
         if (null!=options.get("expireSeconds")) {
             expire = (long) (int)options.get("expireSeconds");
         }
-        return UrlGen.generateUrl(path,urlEndpoint,src,queryParams,transformation,transformationPosition,signed,expire);
+        try {
+            return UrlGen.generateUrl(path,urlEndpoint,src,queryParams,transformation,transformationPosition,signed,expire);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private static String generateUrl(
@@ -41,7 +49,7 @@ public class UrlGen {
             String transformationPosition,
             boolean signed,
             long expireSeconds
-    ){
+    ) throws Exception {
         Configuration config=ImageKit.getInstance().getConfig();
         if (urlEndpoint==null){
             urlEndpoint= config.getUrlEndpoint();
@@ -58,13 +66,21 @@ public class UrlGen {
                 newUrl=buildFullUrl(urlEndpoint+(path.charAt(0)=='/'?path.substring(1,path.length()):path),queryParameters,transformation,transformationPosition,signed,expireSeconds, config.getPrivateKey(), urlEndpoint);
             }
             else {
-                newUrl = buildPathUrl(path.charAt(0)=='/'?path:"/"+path, urlEndpoint, queryParameters, transformation, transformationPosition, signed, expireSeconds, config.getPrivateKey());
+                newUrl = buildPathUrl(path, urlEndpoint, queryParameters, transformation, transformationPosition, signed, expireSeconds, config.getPrivateKey());
             }
         }
         return newUrl;
     }
 
-    private static String buildPathUrl(String path, String urlEndpoint, Map<String, String> queryParameters, List<Map<String, String>> transformation, String transformationPosition, boolean signed, long expireSeconds, String privateKey) {
+    private static String buildPathUrl(String path, String urlEndpoint, Map<String, String> queryParameters, List<Map<String, String>> transformation, String transformationPosition, boolean signed, long expireSeconds, String privateKey) throws Exception{
+        // First strip off any leading /
+        path = path.startsWith("/") ? path.substring(1) : path;
+
+        // Then ensure the supplied path is always url encoded
+        path = URLEncoder.encode(path, StandardCharsets.UTF_8.name());
+
+        // Then ensure it always begins with a /
+        path = path.charAt(0) == '/' ? path : "/" + path;
 
         StringBuilder tr= new StringBuilder("");
         if (transformation.size()>0) {
@@ -95,31 +111,24 @@ public class UrlGen {
         }
 
         URI baseUrl=URI.create(urlEndpoint);
-        URI newUri= null;
-        try {
+        URL newUri= null;
             String newPath=baseUrl.getPath();
-            if (tr.toString().equalsIgnoreCase("")){
-                newPath+=path.substring(1,path.length());
-            }
-            else {
-                newPath+=tr+path;
+            if (tr.toString().equalsIgnoreCase("")) {
+                newPath += path.substring(1);
+            } else {
+                newPath += tr + path;
             }
 
-            URI tmpUri = new URI(baseUrl.getScheme(),baseUrl.getUserInfo(),baseUrl.getHost(),baseUrl.getPort(),
-                    newPath,
-                    queryMaker.get(),null);
+            URL tmpUri = new URL(baseUrl.getScheme(), baseUrl.getHost(), baseUrl.getPort(),
+                    newPath + queryMaker.getAsQueryString(), null);
 
             if (signed){
-                sign(urlEndpoint, expireSeconds, privateKey, queryMaker, tmpUri);
+                sign(urlEndpoint, expireSeconds, privateKey, queryMaker, tmpUri.toURI());
             }
 
-            newUri = new URI(baseUrl.getScheme(),baseUrl.getUserInfo(),baseUrl.getHost(),baseUrl.getPort(),
-                    newPath,
-                    queryMaker.get(),null);
+            newUri = new URL(baseUrl.getScheme(), baseUrl.getHost(), baseUrl.getPort(),
+                    newPath + queryMaker.getAsQueryString(), null);
 
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
         return newUri.toString();
     }
 

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/UrlGen.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/UrlGen.java
@@ -114,16 +114,17 @@ public class UrlGen {
         URL newUri= null;
             String newPath=baseUrl.getPath();
             if (tr.toString().equalsIgnoreCase("")) {
-                newPath += path.substring(1);
+                newPath+=path.substring(1);
             } else {
-                newPath += tr + path;
+                newPath+=tr+path;
             }
 
-            URL tmpUri = new URL(baseUrl.getScheme(), baseUrl.getHost(), baseUrl.getPort(),
+            // Not using URI class here since it will URL encode the path again
+            URL tmpUrl = new URL(baseUrl.getScheme(), baseUrl.getHost(), baseUrl.getPort(),
                     newPath + queryMaker.getAsQueryString(), null);
 
             if (signed){
-                sign(urlEndpoint, expireSeconds, privateKey, queryMaker, tmpUri.toURI());
+                sign(urlEndpoint, expireSeconds, privateKey, queryMaker, tmpUrl.toURI());
             }
 
             newUri = new URL(baseUrl.getScheme(), baseUrl.getHost(), baseUrl.getPort(),

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/UrlGen.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/UrlGen.java
@@ -76,8 +76,10 @@ public class UrlGen {
         // First strip off any leading /
         path = path.startsWith("/") ? path.substring(1) : path;
 
-        // Then ensure the supplied path is always url encoded
-        path = URLEncoder.encode(path, StandardCharsets.UTF_8.name());
+        // Then ensure the supplied path is always url encoded if it is a full url
+        if (isValidUrl(path)) {
+            path = URLEncoder.encode(path, StandardCharsets.UTF_8.name());
+        }
 
         // Then ensure it always begins with a /
         path = path.charAt(0) == '/' ? path : "/" + path;
@@ -221,5 +223,14 @@ public class UrlGen {
         }
         String replaceUrl=url.replace(urlEndpoint,"")+expiryTimestamp;
         return HmacUtils.hmacSha1Hex(privateKey, replaceUrl);
+    }
+
+    public static boolean isValidUrl(String path) {
+        try {
+            URI.create(path).toURL();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/imagekit-sdk/src/test/java/io/imagekit/sdk/ImageKitTest.java
+++ b/imagekit-sdk/src/test/java/io/imagekit/sdk/ImageKitTest.java
@@ -7,21 +7,18 @@ import io.imagekit.sdk.models.FileCreateRequest;
 import io.imagekit.sdk.models.FileUpdateRequest;
 import io.imagekit.sdk.models.results.*;
 import io.imagekit.sdk.tasks.RestClient;
-import io.imagekit.sdk.tasks.UrlGen;
 import io.imagekit.sdk.utils.Utils;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ImageKitTest {
     private static final Pattern IMAGEKIT_SIGNED_URL_PATTERN = Pattern.compile("(https://.*)\\?ik-sdk-version=(.*)&ik-s=(.*)&ik-t=(.*)");
@@ -108,6 +105,34 @@ public class ImageKitTest {
         options.put("transformation",transformation);
         String url=SUT.getUrl(options);
         assertThat(SUT.getConfig().getUrlEndpoint()+"tr:w-400,h-600/default-image.jpg?ik-sdk-version="+ Version.VERSION_CODE,is(url));
+    }
+
+    @Test
+    public void getUrl_with_full_url_in_path_with_signature() {
+        List<Map<String, String>> transformation=new ArrayList<Map<String, String>>();
+        Map<String,Object> options=new HashMap<>();
+        options.put("path","http://placehold.it/1024x1025?text=test");
+        options.put("transformation",transformation);
+        options.put("signed", true);
+        options.put("expireSeconds", 1000);
+        String url=SUT.getUrl(options);
+        assertSignedUrl(SUT.getConfig().getUrlEndpoint() + "http%3A%2F%2Fplacehold.it%2F1024x1025%3Ftext%3Dtest", url);
+    }
+
+    @Test
+    public void getUrl_with_full_url_in_path_with_transform_with_signature() {
+        List<Map<String, String>> transformation=new ArrayList<Map<String, String>>();
+        Map<String, String> scale=new HashMap<>();
+        scale.put("height","600");
+        scale.put("width","400");
+        transformation.add(scale);
+        Map<String,Object> options=new HashMap<>();
+        options.put("path","http://placehold.it/1024x1025?text=test");
+        options.put("transformation",transformation);
+        options.put("signed", true);
+        options.put("expireSeconds", 1000);
+        String url=SUT.getUrl(options);
+        assertSignedUrl(SUT.getConfig().getUrlEndpoint() + "tr:w-400,h-600/http%3A%2F%2Fplacehold.it%2F1024x1025%3Ftext%3Dtest", url);
     }
 
     @Test

--- a/imagekit-sdk/src/test/java/io/imagekit/sdk/ImageKitTest.java
+++ b/imagekit-sdk/src/test/java/io/imagekit/sdk/ImageKitTest.java
@@ -61,6 +61,17 @@ public class ImageKitTest {
     }
 
     @Test
+    public void getUrl_with_relative_and_nested_path() {
+        List<Map<String, String>> transformation=new ArrayList<Map<String, String>>();
+
+        Map<String,Object> options=new HashMap<>();
+        options.put("path","/path1/path2/default-image.jpg");
+        options.put("transformation",transformation);
+        String url=SUT.getUrl(options);
+        assertThat(SUT.getConfig().getUrlEndpoint()+"path1/path2/default-image.jpg?ik-sdk-version="+ Version.VERSION_CODE,is(url));
+    }
+
+    @Test
     public void getUrl_with_height_width_options_url_version_check() {
         List<Map<String, String>> transformation=new ArrayList<Map<String, String>>();
         Map<String, String> scale=new HashMap<>();

--- a/imagekit-sdk/src/test/java/io/imagekit/sdk/ImageKitTest.java
+++ b/imagekit-sdk/src/test/java/io/imagekit/sdk/ImageKitTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -133,6 +134,23 @@ public class ImageKitTest {
         options.put("expireSeconds", 1000);
         String url=SUT.getUrl(options);
         assertSignedUrl(SUT.getConfig().getUrlEndpoint() + "tr:w-400,h-600/http%3A%2F%2Fplacehold.it%2F1024x1025%3Ftext%3Dtest", url);
+    }
+
+    @Test
+    public void getUrl_with_full_url_in_path_with_transform_withDefaultImage_with_signature() {
+        List<Map<String, String>> transformation=new ArrayList<Map<String, String>>();
+        Map<String, String> scale=new HashMap<>();
+        scale.put("height","600");
+        scale.put("width","400");
+        transformation.add(scale);
+        transformation.add(singletonMap("defaultImage", "fallbackImage.jpg"));
+        Map<String,Object> options=new HashMap<>();
+        options.put("path","http://placehold.it/1024x1025?text=test");
+        options.put("transformation",transformation);
+        options.put("signed", true);
+        options.put("expireSeconds", 1000);
+        String url=SUT.getUrl(options);
+        assertSignedUrl(SUT.getConfig().getUrlEndpoint() + "tr:w-400,h-600:di-fallbackImage.jpg/http%3A%2F%2Fplacehold.it%2F1024x1025%3Ftext%3Dtest", url);
     }
 
     @Test

--- a/imagekit-sdk/src/test/java/io/imagekit/sdk/tasks/UrlGenTest.java
+++ b/imagekit-sdk/src/test/java/io/imagekit/sdk/tasks/UrlGenTest.java
@@ -2,6 +2,7 @@ package io.imagekit.sdk.tasks;
 
 import org.junit.Test;
 
+import static io.imagekit.sdk.tasks.UrlGen.isValidUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
@@ -28,5 +29,15 @@ public class UrlGenTest {
         String signature = UrlGen.signUrl("private_key_test", url, "https://test-domain.com/test-endpoint", 0);
         assertThat("41b3075c40bc84147eb71b8b49ae7fbf349d0f00",is(signature));
 
+    }
+
+    @Test
+    public void testIsValidUrl() {
+        assertFalse(isValidUrl("/bla"));
+        assertFalse(isValidUrl("http:"));
+        assertFalse(isValidUrl("http://"));
+        assertTrue(isValidUrl("http:/bla"));
+        assertTrue(isValidUrl("http://bla.com"));
+        assertTrue(isValidUrl("http://bla.com/path/file.txt"));
     }
 }


### PR DESCRIPTION
Recently we encountered a problem whereby our signed urls were not working in all geographic AWS regions.

Here is the example url that we generated with the Imagekit client.
```
http://ik.imagekit.io/<hidden>/tr:n-product_small:di-testing@@logo_icon_only_2020.08.png/http://placehold.it/1024x1024?text=test?ik-sdk-version=java-1.0.3&ik-s=c644f4594246d8f44b91b69b4c8a1ea043b0d3ac
```

I tested with this command:
```
curl -v "http://ik.imagekit.io/<hidden>/tr:n-product_small:di-testing@@logo_icon_only_2020.08.png/http://placehold.it/1024x1024?text=test?ik-sdk-version=java-1.0.3&ik-s=c644f4594246d8f44b91b69b4c8a1ea043b0d3ac"
```

I've tested it on a number of our environments (globally distributed) and got the following results.
Note the first value is the HTTP response code and the last is a header added by your CDN.
```
* 200 - GCP AU - served from edge: X-Amz-Cf-Pop: SYD1-C2
* 401 - GCP US - served from edge: X-Amz-Cf-Pop: ORD52-C1
* 401 - Buildserver US - served from edge: X-Amz-Cf-Pop: ORD52-C1
* 401 - Mediatemple US - served from edge: X-Amz-Cf-Pop: IAD89-C1
* 200 - Local machine (NZ) - served from edge: X-Amz-Cf-Pop: SYD1-C2
```

In the requests that fail I can also see:
```
X-Cache: Error from cloudfront
```

Imagekit support suggested we url-encode the source image url. Unfortunately this did not work since the Imagekit client ends up double url-encoding it when we do that.

This PR fixes the Imagekit client by always url-encoding the supplied image path. 
With this change the client now produces a url like this (using the same inputs)
```
 http://ik.imagekit.io/<hidden>/tr:n-product_small:di-testing@@logo_icon_only_2020.08.png/http%3A%2F%2Fplacehold.it%2F1024x1025%3Ftext%3Dtest?ik-sdk-version=java-1.0.3&ik-s=b407dbd447207b68637025ad5c9c8646e017c4ae
```
