### PR TITLE
Make Result class containt Java's BufferedImage field

### DIFF
--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/ImageKit.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/ImageKit.java
@@ -16,6 +16,7 @@ import io.imagekit.sdk.tasks.Calculation;
 import io.imagekit.sdk.tasks.RestClient;
 import io.imagekit.sdk.tasks.UrlGen;
 
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Map;
 
@@ -88,7 +89,7 @@ public final class ImageKit {
 	 * @return object of Result class
 	 */
 	public Result upload(FileCreateRequest fileCreateRequest) throws InternalServerException, BadRequestException,
-			UnknownException, ForbiddenException, TooManyRequestsException, UnauthorizedException {
+			UnknownException, ForbiddenException, TooManyRequestsException, UnauthorizedException, MalformedURLException {
 		return restClient.upload(fileCreateRequest);
 	}
 

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/models/FileCreateRequest.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/models/FileCreateRequest.java
@@ -29,23 +29,27 @@ public class FileCreateRequest {
 	public Boolean overwriteTags;
 	public Boolean overwriteCustomMetadata;
 	public JsonObject customMetadata;
+	public boolean isReadableImage;
 
 	public FileCreateRequest(URL url, String fileName) {
 		this.url = url;
 		this.fileName = fileName;
 		this.useUniqueFileName = true;
+		this.isReadableImage = Utils.isReadableImage(url);
 	}
 
 	public FileCreateRequest(String base64, String fileName) {
 		this.base64 = base64;
 		this.fileName = fileName;
 		this.useUniqueFileName = true;
+		this.isReadableImage = Utils.isReadableImage(base64);
 	}
 
 	public FileCreateRequest(byte[] bytes, String fileName) {
 		this.bytes = bytes;
 		this.fileName = fileName;
 		this.useUniqueFileName = true;
+		this.isReadableImage = Utils.isReadableImage(bytes);
 	}
 
 	public String getFileName() {
@@ -158,6 +162,14 @@ public class FileCreateRequest {
 
 	public void setCustomMetadata(JsonObject customMetadata) {
 		this.customMetadata = customMetadata;
+	}
+
+	public boolean isReadableImage() {
+		return isReadableImage;
+	}
+
+	public void setReadableImage(boolean readableImage) {
+		isReadableImage = readableImage;
 	}
 
 	@Override

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/models/results/Result.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/models/results/Result.java
@@ -4,16 +4,26 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-
 import io.imagekit.sdk.models.BaseFile;
 import io.imagekit.sdk.models.ResponseMetaData;
+import io.imagekit.sdk.utils.Utils;
 
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class Result extends BaseFile {
+	private BufferedImage image;
 	private String help;
 	@Deprecated
 	private String raw;
@@ -48,6 +58,14 @@ public class Result extends BaseFile {
 		this.hasAlpha = hasAlpha;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
+	}
+
+	public BufferedImage getImage() {
+		return this.image;
+	}
+
+	public void setImage(BufferedImage image) {
+		this.image = image;
 	}
 
 	public String getHelp() {

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/RestClient.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/tasks/RestClient.java
@@ -39,6 +39,8 @@ import okhttp3.*;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +64,7 @@ public class RestClient {
 	}
 
 	public Result upload(FileCreateRequest fileCreateRequest) throws InternalServerException, BadRequestException,
-			UnknownException, ForbiddenException, TooManyRequestsException, UnauthorizedException {
+			UnknownException, ForbiddenException, TooManyRequestsException, UnauthorizedException, MalformedURLException {
 		Result result = null;
 		Map<String, String> headers = Utils.getHeaders(imageKit);
 
@@ -86,6 +88,9 @@ public class RestClient {
 					response.headers().toMultimap());
 		} catch (IOException e) {
 			throw new UnknownException(e.getMessage(), e.getCause());
+		}
+		if(fileCreateRequest.isReadableImage()) {
+			result.setImage(Utils.createImage(new URL(result.getUrl())));
 		}
 		return result;
 	}

--- a/imagekit-sdk/src/main/java/io/imagekit/sdk/utils/Utils.java
+++ b/imagekit-sdk/src/main/java/io/imagekit/sdk/utils/Utils.java
@@ -21,7 +21,10 @@ import io.imagekit.sdk.models.results.ResultException;
 import okhttp3.Credentials;
 import okhttp3.Response;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.*;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -182,4 +185,29 @@ public class Utils {
 		return result;
 	}
 
+	public static BufferedImage createImage(URL url) {
+		try {
+			return ImageIO.read(url);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static boolean isReadableImage(String base64) {
+		byte[] bytes = Base64.getDecoder().decode(base64);
+		return isReadableImage(bytes);
+	}
+
+	public static boolean isReadableImage(byte[] bytes) {
+		InputStream inputStream = new ByteArrayInputStream(bytes);
+		try {
+			return ImageIO.read(inputStream) != null;
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static boolean isReadableImage(URL url) {
+		return createImage(url) != null;
+	}
 }

--- a/imagekit-sdk/src/test/java/io/imagekit/sdk/utils/UtilsTest.java
+++ b/imagekit-sdk/src/test/java/io/imagekit/sdk/utils/UtilsTest.java
@@ -95,6 +95,12 @@ public class UtilsTest {
     }
 
     @Test
+    public void nonImageURL_isReadableImage_expectedFalse() {
+        URL nonImageURL = UtilsTest.class.getClassLoader().getResource("not_an_image.txt");
+        assertFalse(Utils.isReadableImage(nonImageURL));
+    }
+
+    @Test
     public void validImageByteArray_isReadableImage_expectedTrue() {
         URL imageURL = UtilsTest.class.getClassLoader().getResource("sample1.jpg");
         File file=new File(imageURL.getPath());
@@ -103,10 +109,26 @@ public class UtilsTest {
     }
 
     @Test
+    public void nonImageByteArray_isReadableImage_expectedFalse() {
+        URL imageURL = UtilsTest.class.getClassLoader().getResource("not_an_image.txt");
+        File file=new File(imageURL.getPath());
+        byte[] bytes = Utils.fileToBytes(file);
+        assertFalse(Utils.isReadableImage(bytes));
+    }
+
+    @Test
     public void validImageBase64_isReadableImage_expectedTrue() {
         URL imageURL = UtilsTest.class.getClassLoader().getResource("sample1.jpg");
         File file=new File(imageURL.getPath());
         String base64 = Utils.fileToBase64(file);
         assertTrue(Utils.isReadableImage(base64));
+    }
+
+    @Test
+    public void nonImageBase64_isReadableImage_expectedFalse() {
+        URL imageURL = UtilsTest.class.getClassLoader().getResource("not_an_image.txt");
+        File file=new File(imageURL.getPath());
+        String base64 = Utils.fileToBase64(file);
+        assertFalse(Utils.isReadableImage(base64));
     }
 }

--- a/imagekit-sdk/src/test/java/io/imagekit/sdk/utils/UtilsTest.java
+++ b/imagekit-sdk/src/test/java/io/imagekit/sdk/utils/UtilsTest.java
@@ -87,4 +87,26 @@ public class UtilsTest {
         Configuration config=Utils.getSystemConfig(UtilsTest.class);
         assertNotNull(config);
     }
+
+    @Test
+    public void validImageURL_isReadableImage_expectedTrue() {
+        URL imageURL = UtilsTest.class.getClassLoader().getResource("sample1.jpg");
+        assertTrue(Utils.isReadableImage(imageURL));
+    }
+
+    @Test
+    public void validImageByteArray_isReadableImage_expectedTrue() {
+        URL imageURL = UtilsTest.class.getClassLoader().getResource("sample1.jpg");
+        File file=new File(imageURL.getPath());
+        byte[] bytes = Utils.fileToBytes(file);
+        assertTrue(Utils.isReadableImage(bytes));
+    }
+
+    @Test
+    public void validImageBase64_isReadableImage_expectedTrue() {
+        URL imageURL = UtilsTest.class.getClassLoader().getResource("sample1.jpg");
+        File file=new File(imageURL.getPath());
+        String base64 = Utils.fileToBase64(file);
+        assertTrue(Utils.isReadableImage(base64));
+    }
 }

--- a/imagekit-sdk/src/test/resources/not_an_image.txt
+++ b/imagekit-sdk/src/test/resources/not_an_image.txt
@@ -1,0 +1,1 @@
+This file is not an image.


### PR DESCRIPTION
Hi. I've been recently using ImageKit library for Java, mainly for uploading images programmatically. Throughout my not-so-long experimenting with it, I've found that it may perhaps be helpful to have a ready-to-use Java AWT's image object after having sent an image to external hosting (ImageKit :) ).

I've taken a stab at trying to accomplish so.

**GOAL**: Result class contains BufferedImage field

**Problem**: Not every file needs to be an image and not every image will neccessarily be read by `ImageIO.read`.
In `FileCreateRequest` class, I've added `isReadableImage` field, which is set whenever any of the 3 constructors is called.
In `Utils`, I've written `isReadableImage` methods. They take a reference to image source in forms of base64-encoded string, simple String path or instance of `URL` class. I've also written tests for them which pass (they test for both files that are images, and for simple .txt file). **Note**: the `isReadableImage` method will not return `true` for every image as `ImageIO.read` does not support every format. For example, in order to read `.webp` images this way, we would additionally need plugins, which I've not included.

I've also thought of creating another Result class, especially for images, but I realised it may be too much at once ;)

This is my first contribution to open source project, I'd love some feedback. I'm open to work on this as well as on other issues.